### PR TITLE
Dj/eng 593 housekeeping normalize logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,16 +6,17 @@ godebug default=go1.23
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.2
-	github.com/decisiveai/mdai-data-core v0.1.4-0.20250522133232-4aa0a4c57198
+	github.com/decisiveai/mdai-data-core v0.1.7
 	github.com/decisiveai/opentelemetry-operator v0.113.0
 	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/zapr v1.3.0
 	github.com/onsi/ginkgo/v2 v2.22.1
 	github.com/onsi/gomega v1.36.2
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.79.2
 	github.com/prometheus/prometheus v0.55.0
 	github.com/stretchr/testify v1.10.0
-	github.com/valkey-io/valkey-go v1.0.54
-	github.com/valkey-io/valkey-go/mock v1.0.54
+	github.com/valkey-io/valkey-go v1.0.57
+	github.com/valkey-io/valkey-go/mock v1.0.57
 	go.opentelemetry.io/contrib/bridges/otellogr v0.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.11.0
@@ -52,7 +53,6 @@ require (
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/decisiveai/mdai-data-core v0.1.4-0.20250522133232-4aa0a4c57198 h1:eJPBIDrN1D8Lpkd6P0dTQ3NsGLrKLjym94gU8S9Nbs4=
-github.com/decisiveai/mdai-data-core v0.1.4-0.20250522133232-4aa0a4c57198/go.mod h1:p0SddsX91XArs/2w1fVcF8C/zNSoJpaNaYmnAfFiZDw=
+github.com/decisiveai/mdai-data-core v0.1.7 h1:e0rdqufNAzVAtoqEKw7yLyCaa2CfiG+Eh0ThIYMOTX8=
+github.com/decisiveai/mdai-data-core v0.1.7/go.mod h1:dTRzTEL2nUzgC+tw0UqJhHnhPqG9/QD3Ry6lUaiLF7g=
 github.com/decisiveai/opentelemetry-operator v0.113.0 h1:IWW4WmXR1QR2FAs2GIz8h3WPzh2hqoVQqsbKsVz/1nc=
 github.com/decisiveai/opentelemetry-operator v0.113.0/go.mod h1:fzTghQy29Mahmh/nqD2ORMHfJ57nqsvuxmxpdDfkQ90=
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
@@ -297,10 +297,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/valkey-io/valkey-go v1.0.54 h1:pmFRGcMRJW8mHvsWLd/2MSgY6i3WNygpUl904KUaxao=
-github.com/valkey-io/valkey-go v1.0.54/go.mod h1:NE+C8cjb3+XvLazNhiorcLJGhJa9MBAkFNoAW/48/fk=
-github.com/valkey-io/valkey-go/mock v1.0.54 h1:qYZBT1F5g3i+537nCTgkHPM4S+BQeAmZG6DmLvdu990=
-github.com/valkey-io/valkey-go/mock v1.0.54/go.mod h1:6l1WZK0gFzCrzcrCqpqpNAh94EZeRWaD42EvGBg/ris=
+github.com/valkey-io/valkey-go v1.0.57 h1:rMpREZ7kvWwv9vHkB1WTpI9rX4dQHsvPHimSWenScvI=
+github.com/valkey-io/valkey-go v1.0.57/go.mod h1:sxpCChk8i3oTG+A/lUi9Lj8C/7WI+yhnQCvDJlPVKNM=
+github.com/valkey-io/valkey-go/mock v1.0.57 h1:ft06MuqCCKlob/R5dzUv4zNnNu+GaqElalApOFS5Fc4=
+github.com/valkey-io/valkey-go/mock v1.0.57/go.mod h1:VDiXrmHdRCz/UT4xzMkfQEc5iHa7naDpqsZ+lotmJE8=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/internal/controller/hub_adapter.go
+++ b/internal/controller/hub_adapter.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"slices"
 	"strings"
 	"time"
@@ -153,7 +154,7 @@ func (c HubAdapter) finalizeHub(ctx context.Context) (ObjectState, error) {
 
 	prefix := VariableKeyPrefix + c.mdaiCR.Name + "/"
 	c.logger.Info("Cleaning up old variables from Valkey with prefix", "prefix", prefix)
-	if err := datacore.NewValkeyAdapter(c.valKeyClient, c.logger).DeleteKeysWithPrefixUsingScan(ctx, map[string]struct{}{}, c.mdaiCR.Name); err != nil {
+	if err := datacore.NewValkeyAdapter(c.valKeyClient, zap.NewRaw()).DeleteKeysWithPrefixUsingScan(ctx, map[string]struct{}{}, c.mdaiCR.Name); err != nil {
 		return ObjectUnchanged, err
 	}
 
@@ -418,7 +419,7 @@ func (c HubAdapter) ensureVariableSynced(ctx context.Context) (OperationResult, 
 			namespaceToRestart[namespace] = struct{}{}
 		}
 	}
-	auditAdapter := audit.NewAuditAdapter(c.logger, c.valKeyClient, c.valkeyAuditStreamExpiry)
+	auditAdapter := audit.NewAuditAdapter(zap.NewRaw(), c.valKeyClient, c.valkeyAuditStreamExpiry)
 
 	for _, collector := range collectors {
 		if _, shouldRestart := namespaceToRestart[collector.Namespace]; shouldRestart {

--- a/internal/controller/hub_adapter_test.go
+++ b/internal/controller/hub_adapter_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valkey-io/valkey-go"
+	"go.uber.org/zap"
 	"k8s.io/utils/ptr"
 
 	v1 "github.com/decisiveai/mdai-operator/api/v1"
@@ -95,7 +96,7 @@ func TestFinalizeHub_Success(t *testing.T) {
 	fakeValkey.EXPECT().Do(ctx, fakeValkey.B().Del().Key(VariableKeyPrefix+mdaiCR.Name+"/"+"key").Build()).
 		Return(mock.Result(mock.ValkeyInt64(1)))
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
 
 	state, err := adapter.finalizeHub(ctx)
 	if err != nil {
@@ -140,7 +141,7 @@ func TestEnsureFinalizerInitialized_AddsFinalizer(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 	_, err := adapter.ensureFinalizerInitialized(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -172,7 +173,7 @@ func TestEnsureFinalizerInitialized_AlreadyPresent(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 	_, err := adapter.ensureFinalizerInitialized(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -195,7 +196,7 @@ func TestEnsureStatusInitialized_SetsInitialStatus(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 	_, err := adapter.ensureStatusInitialized(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -251,7 +252,7 @@ func TestDeleteFinalizer(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 	if err := adapter.deleteFinalizer(ctx, mdaiCR, hubFinalizer); err != nil {
 		t.Fatalf("deleteFinalizer returned error: %v", err)
 	}
@@ -271,7 +272,7 @@ func TestCreateOrUpdateEnvConfigMap(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 	envMap := map[string]string{"VAR": "value"}
 	if _, err := adapter.createOrUpdateEnvConfigMap(ctx, envMap, envConfigMapNamePostfix, "default"); err != nil {
 		t.Fatalf("createOrUpdateEnvConfigMap returned error: %v", err)
@@ -294,7 +295,7 @@ func TestCreateOrUpdateManualEnvConfigMap(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 	envMap := map[string]string{"VAR": "string"}
 	if _, err := adapter.createOrUpdateEnvConfigMap(ctx, envMap, manualEnvConfigMapNamePostfix, "default"); err != nil {
 		t.Fatalf("createOrUpdateEnvConfigMap returned error: %v", err)
@@ -325,7 +326,7 @@ func TestBuildCollectorConfig(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 	config, err := adapter.getObserverCollectorConfig(observers, observerResource)
 	if err != nil {
 		t.Fatalf("getObserverCollectorConfig returned error: %v", err)
@@ -498,7 +499,7 @@ func TestEnsureVariableSynced(t *testing.T) {
 	fakeValkey.EXPECT().Do(ctx, fakeValkey.B().Del().Key(VariableKeyPrefix+mdaiCR.Name+"/"+"key").Build()).
 		Return(mock.Result(mock.ValkeyInt64(1)))
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
 
 	opResult, err := adapter.ensureVariableSynced(ctx)
 	if err != nil {
@@ -584,7 +585,7 @@ func TestEnsureManualAndComputedVariableSynced(t *testing.T) {
 	fakeValkey.EXPECT().Do(ctx, fakeValkey.B().Del().Key(VariableKeyPrefix+mdaiCR.Name+"/"+"key").Build()).
 		Return(mock.Result(mock.ValkeyInt64(1)))
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
 
 	opResult, err := adapter.ensureVariableSynced(ctx)
 	if err != nil {
@@ -670,7 +671,7 @@ func TestEnsureEvaluationsSynchronized_WithEvaluations(t *testing.T) {
 
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 
 	opResult, err := adapter.ensurePrometheusAlertsSynchronized(ctx)
 	if err != nil {
@@ -729,7 +730,7 @@ func TestEnsureEvaluationsSynchronized_NoEvaluations(t *testing.T) {
 
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 
 	opResult, err := adapter.ensurePrometheusAlertsSynchronized(ctx)
 	if err != nil {
@@ -773,7 +774,7 @@ func TestEnsureHubDeletionProcessed_WithDeletion(t *testing.T) {
 	fakeValkey.EXPECT().Do(ctx, fakeValkey.B().Del().Key(VariableKeyPrefix+mdaiCR.Name+"/"+"key").Build()).
 		Return(mock.Result(mock.ValkeyInt64(1)))
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, fakeValkey, time.Duration(30))
 
 	opResult, err := adapter.ensureHubDeletionProcessed(ctx)
 	if err != nil {
@@ -833,7 +834,7 @@ func TestEnsureObserversSynchronized_WithObservers(t *testing.T) {
 
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 
 	// Call ensureObserversSynchronized.
 	opResult, err := adapter.ensureObserversSynchronized(ctx)
@@ -889,7 +890,7 @@ func TestEnsureStatusSetToDone(t *testing.T) {
 	fakeClient := newFakeClientForCR(mdaiCR, scheme)
 	recorder := record.NewFakeRecorder(10)
 
-	adapter := NewHubAdapter(mdaiCR, logr.Discard(), fakeClient, recorder, scheme, nil, time.Duration(30))
+	adapter := NewHubAdapter(mdaiCR, logr.Discard(), zap.NewNop(), fakeClient, recorder, scheme, nil, time.Duration(30))
 
 	opResult, err := adapter.ensureStatusSetToDone(ctx)
 	if err != nil {

--- a/internal/controller/mdaihub_controller.go
+++ b/internal/controller/mdaihub_controller.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -60,6 +61,7 @@ const (
 // MdaiHubReconciler reconciles a MdaiHub object
 type MdaiHubReconciler struct {
 	client.Client
+	ZapLogger    *zap.Logger
 	Scheme       *runtime.Scheme
 	Recorder     record.EventRecorder
 	ValKeyClient valkey.Client
@@ -97,7 +99,7 @@ func (r *MdaiHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	_, err := r.ReconcileHandler(ctx, *NewHubAdapter(fetchedCR, log, r.Client, r.Recorder, r.Scheme, r.ValKeyClient, r.ValkeyExpiry))
+	_, err := r.ReconcileHandler(ctx, *NewHubAdapter(fetchedCR, log, r.ZapLogger, r.Client, r.Recorder, r.Scheme, r.ValKeyClient, r.ValkeyExpiry))
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Preserve `*zap.Logger` in top level structs to pass to data-core as appropriate.